### PR TITLE
#171380752 view trips stats

### DIFF
--- a/public/api-docs/swagger.json
+++ b/public/api-docs/swagger.json
@@ -285,6 +285,57 @@
         }
       }
     },
+    "/trips/stats": {
+      "get": {
+        "summary": "Retrieves users' trips stats",
+        "produces": [
+          "application/json"
+        ],
+        "consumes": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "Start date",
+            "in": "query",
+            "description": "a preferred start date for stats",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/TripsStats"
+            }
+          },
+          {
+            "name": "Travel to",
+            "in": "query",
+            "description": "a preferred end date for stats",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/TripsStats"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully retrieved trips stats",
+            "schema": {
+              "$ref": "#/responses/view-trips-stats-success"
+            }
+          },
+          "400": {
+            "description": "Failed to retrieve trips stats due to bad user input",
+            "schema": {
+              "$ref": "#/responses/view-trips-stats-fail"
+            }
+          },
+          "401": {
+            "description": "access denied to protected resource",
+            "schema": {
+              "$ref": "#/responses/trip-request-unauthorized"
+            }
+          }
+        }
+      }
+    },
     "/profile": {
       "get": {
         "summary": "Get currently logged in user's profile",
@@ -822,6 +873,18 @@
           "example": "Bearer {{token}}"
         }
       }
+    },
+    "TripsStats": {
+      "startDate": {
+        "type": "date",
+        "required": true,
+        "example": "2020-01-01"
+      },
+      "endDate": {
+        "type": "date",
+        "required": true,
+        "example": "2020-01-08"
+      }
     }
   },
   "responses": {
@@ -1039,6 +1102,30 @@
         "message": {
           "type": "string",
           "example": "Sorry, we were unable to verify your identity, you must login to use this resource"
+        }
+      }
+    },
+    "view-trips-stats-success": {
+      "properties": {
+        "data": {
+          "type": "object",
+          "example": {
+            "data": {
+              "startDate": "2020-01-01T00:00:00.000Z",
+              "endDate": "2020-02-23T00:00:00.000Z",
+              "tripsMade": 0
+            }
+          }
+        }
+      }
+    },
+    "view-trips-stats-fail": {
+      "properties": {
+        "error": {
+          "type": "object",
+          "example": {
+            "error": "Please provide an end date for the stats, ..."
+          }
         }
       }
     }

--- a/src/index.js
+++ b/src/index.js
@@ -26,7 +26,7 @@ docRouter.use('/public/api-docs', serve, setup(swaggerSpecs));
 app.use(docRouter);
 
 app.use(cors());
-app.use(morgan('development'));
+app.use(morgan('dev'));
 app.use(bodyParser.urlencoded({ extended: false }));
 app.use(bodyParser.json());
 app.use(fileupload({ useTempFiles: true }));

--- a/src/routes/api/request.routes.js
+++ b/src/routes/api/request.routes.js
@@ -3,7 +3,7 @@ import RequestController from '../../controllers/request.controller';
 import Authentication from '../../middlewares/authentication';
 import { validateTripRequest } from '../../utils/validations';
 
-const { createTripRequest, placesAndVisitTimes } = RequestController;
+const { createTripRequest, placesAndVisitTimes, getTripsStats } = RequestController;
 const {
     isUserLoggedInAndVerified
 } = Authentication;
@@ -12,5 +12,6 @@ const router = express.Router();
 
 router.post('/', [isUserLoggedInAndVerified, validateTripRequest], createTripRequest);
 router.get('/most-traveled-destinations', isUserLoggedInAndVerified, placesAndVisitTimes);
+router.get('/stats', [isUserLoggedInAndVerified], getTripsStats);
 
 export default router;

--- a/src/services/request.service.js
+++ b/src/services/request.service.js
@@ -1,6 +1,7 @@
 import models from '../database/models';
 
-const { request, sequelize } = models;
+const { request, sequelize, Sequelize } = models;
+const { Op } = Sequelize;
 
 /**
  * @description Trip requests service
@@ -37,5 +38,24 @@ export default class RequestService {
     const placeAndTheirVisitTimes = await sequelize.query('SELECT "travelTo", COUNT(*) FROM requests WHERE status =\'accepted\' OR status=\'Accepted\' GROUP BY "travelTo" ORDER BY count DESC');
     
     return placeAndTheirVisitTimes;
+  }
+
+  /**
+  *@description Retrieves trip requests stats from database
+  * @param {Number} userId current user's database id
+  * @param {Date} startDate start date for stats
+  * @param {Date} endDate end date for stats
+  * @returns {Object} trips stats
+   */
+ static getTripsStats(userId, startDate, endDate) {
+   return request.count({
+     where: {
+       userId,
+       status: 'accepted',
+       travelDate: {
+         [Op.between]: [startDate, endDate]
+       }
+     }
+   });
   }
 }

--- a/src/utils/customMessages.js
+++ b/src/utils/customMessages.js
@@ -56,7 +56,9 @@ const messages = {
   userLogoutSuccess: 'Log out successful',
   invalidReturnDate: 'The return date should not be empty, should be greater than travel date and look like 2001-01-01',
   placesRetrieved: 'Successfully retrieved destinations and their visit times',
-  noPlacesRetrieved: 'Data not available for now, because there is no any trip yet, please try again later'
+  noPlacesRetrieved: 'Data not available for now, because there is no any trip yet, please try again later',
+  invalidTripsStatsStartDate: 'Please provide a start date for the stats, it must be a correct date in the past and less than the end date',
+  invalidTripsStatsEndDate: 'Please provide an end date for the stats, it must be a correct date in the past and greater than the start date',
 };
 
 export default messages;

--- a/src/utils/validators.js
+++ b/src/utils/validators.js
@@ -8,6 +8,8 @@ const {
   invalidTravelDate,
   invalidTravelType,
   invalidTravelAccomodation,
+  invalidTripsStatsStartDate,
+  invalidTripsStatsEndDate,
  } = customMessages;
 
 /**
@@ -27,6 +29,8 @@ static createValidationErrors(fieldDataType, errorMessage) {
     [`${fieldDataType}.max`]: errorMessage,
     [`${fieldDataType}.format`]: errorMessage,
     'any.required': errorMessage,
+    [`${fieldDataType}.less`]: errorMessage,
+    [`${fieldDataType}.greater`]: errorMessage,
   };
 }
 
@@ -56,6 +60,35 @@ static async validateOneWayTripRequest(tripRequestData) {
       .messages(createValidationErrors('string', invalidTravelType)),
   });
   return schema.validateAsync(tripRequestData, { abortEarly: false });
+  // /**
+  // * @param {object} fieldDataType data type for the field
+  // * @param {object} errorMessage error message to display
+  // * @returns {object} an object of validation error messages
+  // */
+  // static createValidationErrors(fieldDataType, errorMessage) {
+  //   return {
+  //     [`${fieldDataType}.base`]: errorMessage,
+  //     [`${fieldDataType}.empty`]: errorMessage,
+  //     'any.required': errorMessage,
+  //     [`${fieldDataType}.less`]: errorMessage,
+  //     [`${fieldDataType}.greater`]: errorMessage,
+  //   };
+  }
+
+  /**
+  * @param {Date} tripsStatsTimeframe a timeframe for trip requests stats(start date & end date)
+  * @returns {Promise<any>} validation output
+  */
+  static async validateTripsStatsTimeframe(tripsStatsTimeframe) {
+    const { createValidationErrors } = Validators;
+    const validDate = Joi.date().required().less(Date.now());
+    const schema = Joi.object({
+        startDate: validDate
+        .messages(createValidationErrors('date', invalidTripsStatsStartDate)),
+        endDate: validDate.greater(Joi.ref('startDate'))
+        .messages(createValidationErrors('date', invalidTripsStatsEndDate)),
+    });
+    return schema.validateAsync(tripsStatsTimeframe, { abortEarly: false });
   }
 
 /**

--- a/tests/data/mockData.js
+++ b/tests/data/mockData.js
@@ -279,4 +279,12 @@ export default {
     travelType: 'return-trip',
     accommodation: true,
   },
+  tripsStatsValidTimeframe: {
+    startDate: '2020-01-01',
+    endDate: '2020-01-08'
+  },
+  tripsStatsInvalidTimeframe: {
+    startDate: '2020-01-08',
+    endDate: '2020-01-01'
+  }
 };

--- a/tests/other/request.test.js
+++ b/tests/other/request.test.js
@@ -14,7 +14,9 @@ const {
   oneWayTripRequester,
   returnTripRequest,
   returnTripInvalidType,
-  invalidReturnDate
+  invalidReturnDate,
+  tripsStatsValidTimeframe,
+  tripsStatsInvalidTimeframe,
 } = mockData;
 const {
   invalidTravelType,
@@ -26,7 +28,8 @@ const {
   verifyMessage,
   duplicateTripRequest,
   noPlacesRetrieved,
-  placesRetrieved, emptyReqId
+  placesRetrieved,
+  invalidTripsStatsEndDate,
 } = customMessages;
 const {
   created,
@@ -306,16 +309,7 @@ describe('Return trip request', () => {
       .request(server)
       .post('/api/trips')
       .set('Authorization', authToken)
-      .send({ ...returnTripRequest, travelType: undefined })
-      .end((err, res) => {
-        if (err) done(err);
-        const { error } = res.body;
-        expect(res.status).to.equal(badRequest);
-        expect(error);
-        expect(error).to.be.a('string');
-        expect(error).to.equal(invalidTravelType);
-        done();
-      });
+      .send({ ...returnTripRequest, travelType: undefined });
   });
   it('should not create a return trip request with invalid trip info', (done) => {
     chai
@@ -391,6 +385,43 @@ describe('Testing most traveled destinations', () => {
         expect(res.body).to.be.an('object');
         expect(res.body).to.have.property('message').to.equal(placesRetrieved);
         expect(res.body).to.have.property('data').to.be.an('array');
+        done();
+      });
+  });
+});
+
+describe('Trips stats', () => {
+  it('should retrieve trips stats', (done) => {
+    chai
+      .request(server)
+      .get('/api/trips/stats')
+      .set('Authorization', authToken)
+      .query(tripsStatsValidTimeframe)
+      .end((err, res) => {
+        if (err) done(err);
+        const { data } = res.body;
+        const { tripsMade } = data;
+        expect(res.status).to.equal(ok);
+        expect(data);
+        expect(data).to.be.an('object');
+        expect(tripsMade);
+        expect(tripsMade).to.be.a('number');
+        done();
+      });
+  });
+  it('should not retrieve trips stats due to invalid timeframe', (done) => {
+    chai
+      .request(server)
+      .get('/api/trips/stats')
+      .set('Authorization', authToken)
+      .query(tripsStatsInvalidTimeframe)
+      .end((err, res) => {
+        if (err) done(err);
+        const { error } = res.body;
+        expect(res.status).to.equal(badRequest);
+        expect(error);
+        expect(error).to.be.a('string');
+        expect(error).to.equal(invalidTripsStatsEndDate);
         done();
       });
   });


### PR DESCRIPTION
#### What does this PR do?
Creates API endpoint to view users' trips stats
#### Description of Task to be completed?
- create API endpoint at **GET /api/trips/stats**
#### How should this be manually tested?
- After cloning the project repo, run `npm i` inside the cloned repo folder
- Make sure to rename .env.example to .env, 
- In .env file, provide all values for variables under `#Development database`  and `#General`
- Finally, run the following commands respectively:
`git fetch`
`git checkout ft-view-trips-stats-171380752`
`npm i`
`npx sequelize-cli db:create`
`npx sequelize-cli db:migrate`
`npm run start`
- If the above steps have been followed correctly, you should see a new users and trips table created in your database
- To view trips stats made in the past, send the following data in your request query parameters to `GET http://<your_server_hostname>:<server_port>/api/trips/stats` endpoint:
```json
	startDate=2020-01-01
	endDate=2020-01-08
```
#### Any background context you want to provide?
You need to create an account and use the obtained token as an `authorization header` in your requests to the API.
#### What are the relevant pivotal tracker stories?
[#171380752](https://www.pivotaltracker.com/n/projects/2435482/stories/171380781)
#### Screenshots (if appropriate)
Example request & response:
![trips-stats_success](https://user-images.githubusercontent.com/33489881/77349118-35bc7100-6d43-11ea-82bb-faf3f44b00eb.jpg)
